### PR TITLE
docs: fix simple typo, persistant -> persistent

### DIFF
--- a/rdioapi/__init__.py
+++ b/rdioapi/__init__.py
@@ -66,7 +66,7 @@ class RdioProtocolException(RdioException):
 
 
 class AuthStore(object):
-  """A wrapper around the persistant storage that must be passed in."""
+  """A wrapper around the persistent storage that must be passed in."""
 
   _KEYS = ['device_code', 'device_expires', 'device_interval', 'refresh_token', 'access_token', 'access_token_expires']
 


### PR DESCRIPTION
There is a small typo in rdioapi/__init__.py.

Should read `persistent` rather than `persistant`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md